### PR TITLE
Enable photo deletion by owner in photo details dialog

### DIFF
--- a/Lumix.Blazor/Components/Photo/PhotoDetailsDialog.razor
+++ b/Lumix.Blazor/Components/Photo/PhotoDetailsDialog.razor
@@ -25,7 +25,7 @@
                 </MudItem>
 
                 <MudItem xs="12" md="5" Class="d-flex flex-column">
-                    <PhotoDialogComments Photo="Photo" CurrentUser="CurrentUser" OnAddComment="HandleCommentAdded" />
+                    <PhotoDialogComments Photo="Photo" CurrentUser="CurrentUser" CurrentUserId="CurrentUserId" OnAddComment="HandleCommentAdded" />
                 </MudItem>
             </MudGrid>
         }

--- a/Lumix.Blazor/Components/Photo/PhotoDetailsDialog.razor.cs
+++ b/Lumix.Blazor/Components/Photo/PhotoDetailsDialog.razor.cs
@@ -12,6 +12,7 @@ namespace Lumix.Blazor.Components.Photo
         [CascadingParameter] MudDialogInstance MudDialog { get; set; }
         [Parameter] public Guid PhotoId { get; set; }
         [Parameter] public UserProfileDto CurrentUser { get; set; }
+        [Parameter] public Guid CurrentUserId { get; set; }
         [Inject] public IPhotoService PhotoService { get; set; } = default!;
         [Inject] public ICommentService CommentService { get; set; } = default!;
         [Inject] public ISnackbar Snackbar { get; set; } = default!;

--- a/Lumix.Blazor/Components/Photo/PhotoDialogComments.razor
+++ b/Lumix.Blazor/Components/Photo/PhotoDialogComments.razor
@@ -32,14 +32,34 @@
                 <MudText Typo="Typo.h6">@Photo.Author.Username</MudText>
             </MudStack>
 
-            <MudText Typo="Typo.caption" Color="Color.Default">
-                @Photo.CreatedAt.ToString("dd.MM.yyyy")
-            </MudText>
+            <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
+                <MudText Typo="Typo.caption" Color="Color.Default">
+                    @Photo.CreatedAt.ToString("dd.MM.yyyy")
+                </MudText>
+
+                @if (CanDeletePhoto)
+                {
+                    <MudMenu AnchorOrigin="Origin.TopRight" TransformOrigin="Origin.TopRight" Dense="true">
+                        <ActivatorContent>
+                            <MudIconButton Icon="@Icons.Material.Filled.MoreVert" Size="Size.Small" />
+                        </ActivatorContent>
+
+                        <ChildContent>
+                            <MudMenuItem OnClick="@(() => ConfirmDeletePhoto(Photo.Id))">
+                                <MudIcon Icon="@Icons.Material.Filled.Delete" Class="me-2" />
+                                Видалити фото
+                            </MudMenuItem>
+                        </ChildContent>
+                    </MudMenu>
+                }
+            </MudStack>
         </MudStack>
 
         <MudText Typo="Typo.h6" Class="mb-2">
             @Photo.Title
         </MudText>
+            
+        
 
         @if(Photo.PhotoTags?.Any() == true)
         {

--- a/Lumix.Blazor/Components/Photo/PhotoDialogComments.razor.cs
+++ b/Lumix.Blazor/Components/Photo/PhotoDialogComments.razor.cs
@@ -1,20 +1,35 @@
-﻿using Lumix.Blazor.Data.Comment;
+﻿using System.Runtime.InteropServices;
+using Lumix.Blazor.Data.Comment;
 using Lumix.Blazor.Data.Photo;
 using Lumix.Blazor.Data.User;
+using Lumix.Blazor.Services.IServices;
 using Microsoft.AspNetCore.Components;
+using MudBlazor;
 
 namespace Lumix.Blazor.Components.Photo
 {
     public partial class PhotoDialogComments
     {
+        [CascadingParameter]
+        private MudDialogInstance MudDialog { get; set; } = default!;
         [Parameter] public PhotoDto Photo { get; set; }
         [Parameter] public UserProfileDto CurrentUser { get; set; }
+        [Parameter] public Guid CurrentUserId { get; set; }
         [Parameter] public EventCallback<CommentRequest> OnAddComment { get; set; }
+        [Inject] public IDialogService DialogService { get; set; }
+        [Inject] public IPhotoService PhotoService { get; set; }
+        [Inject] public ISnackbar Snackbar { get; set; }
 
         public string NewComment { get; set; } = string.Empty;
         public Guid? ReplyParentId { get; set; } = null;
         public string? ReplyToUsername { get; set; } = null;
+        public bool CanDeletePhoto { get; set; }
 
+        protected override Task OnInitializedAsync()
+        {
+            CanDeletePhoto = CurrentUserId == Photo.Author.Id;
+            return base.OnInitializedAsync();
+        }
 
         private async Task SubmitComment()
         {
@@ -54,6 +69,23 @@ namespace Lumix.Blazor.Components.Photo
             if (diff.TotalHours < 1) return $"{(int)diff.TotalMinutes} хв тому";
             if (diff.TotalDays < 1) return $"{(int)diff.TotalHours} год тому";
             return $"{(int)diff.TotalDays} дн тому";
+        }
+
+        private async Task ConfirmDeletePhoto(Guid photoId)
+        {
+            var confirmed = await DialogService.ShowMessageBox(
+                "Видалити фото?",
+                "Фото буде видалено назавжди.",
+                yesText: "Видалити",
+                cancelText: "Скасувати"
+            );
+            if (confirmed != true)
+                return;
+            await PhotoService.DeletePhotoAsync(photoId);
+
+            Snackbar.Add("Фото видалено", Severity.Success);
+
+            MudDialog.Close(DialogResult.Ok(photoId));
         }
     }
 }

--- a/Lumix.Blazor/Components/Profile/ProfileCard.razor
+++ b/Lumix.Blazor/Components/Profile/ProfileCard.razor
@@ -2,10 +2,6 @@
 @inherits LayoutComponentBase
 @inject NavigationManager NavigationManager
 
-<style>
-    
-
-</style>
 
 <MudContainer>
 

--- a/Lumix.Blazor/Pages/Profile.razor
+++ b/Lumix.Blazor/Pages/Profile.razor
@@ -3,8 +3,8 @@
 @using Lumix.Blazor.Data.User
 @using Lumix.Blazor.Services.IServices
 @inject IUserService UserService
-@inject ILogger<Profile> Logger
 @inject IDialogService DialogService
+@inject AuthenticationStateProvider AuthStateProvider
 
 @using Lumix.Blazor.Components.Profile;
 
@@ -14,13 +14,15 @@
 
 @code {
     public UserProfileDto ProfileDto { get; set; } = new();
-    private bool isInitialized = false;
+    private bool _isInitialized = false;
+    public Guid CurrentUserId { get; set; }
 
     protected override async Task OnInitializedAsync()
     {
         var result = await UserService.GetProfileAsync();
         ProfileDto = result.Value;
-        isInitialized = true;
+        _isInitialized = true;
+        CurrentUserId = (await UserService.GetMeAsync()).Value;
     }
 
     private async Task OpenPhotoDialog(Guid photoId)
@@ -33,8 +35,15 @@
             CloseButton = true
         };
 
-        var parameters = new DialogParameters { { "PhotoId", photoId }, {"CurrentUser", ProfileDto } };
+        var parameters = new DialogParameters { { "PhotoId", photoId }, {"CurrentUser", ProfileDto }, { "CurrentUserId", CurrentUserId } };
 
-        await DialogService.ShowAsync<PhotoDetailsDialog>("", parameters, options);
+        var dialog = await DialogService.ShowAsync<PhotoDetailsDialog>("", parameters, options);
+        var result = await dialog.Result;
+
+        if (!result.Cancelled && result.Data is Guid deletedPhotoId)
+        {
+            ProfileDto.Photos.RemoveAll(p => p.Id == deletedPhotoId);
+        }
+
     }
 }

--- a/Lumix.Blazor/Services/HttpService.cs
+++ b/Lumix.Blazor/Services/HttpService.cs
@@ -40,6 +40,10 @@ public class HttpService
             }
 
             using var response = await HttpClient.SendAsync(request);
+
+            if (response.StatusCode == System.Net.HttpStatusCode.NoContent)
+                return ApiResult<T>.Success(default);
+
             var content = await response.Content.ReadAsStringAsync();
 
             _logger.LogInformation($"Response status: {response.StatusCode}, Content: {content}");
@@ -75,6 +79,12 @@ public class HttpService
     {
         using var request = new HttpRequestMessage(HttpMethod.Post, endpoint);
         request.Content = formData;
+        return await SendRequestAsync<T>(request);
+    }
+
+    public async Task<ApiResult<T>> DeleteAsync<T>(string uri)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Delete, uri);
         return await SendRequestAsync<T>(request);
     }
 }

--- a/Lumix.Blazor/Services/IServices/IPhotoService.cs
+++ b/Lumix.Blazor/Services/IServices/IPhotoService.cs
@@ -8,4 +8,5 @@ public interface IPhotoService
 {
     Task<ApiResult<PhotoUploadResponseDto>> UploadPhotoAsync(PhotoUploadDto uploadDto);
     Task<ApiResult<PhotoDto>> GetPhotoByIdAsync(Guid photoId);
+    Task<ApiResult<object>> DeletePhotoAsync(Guid photoId);
 }

--- a/Lumix.Blazor/Services/IServices/IUserService.cs
+++ b/Lumix.Blazor/Services/IServices/IUserService.cs
@@ -6,5 +6,6 @@ namespace Lumix.Blazor.Services.IServices
     public interface IUserService
     {
         Task<ApiResult<UserProfileDto>> GetProfileAsync();
+        public Task<ApiResult<Guid>> GetMeAsync();
     }
 }

--- a/Lumix.Blazor/Services/PhotoService.cs
+++ b/Lumix.Blazor/Services/PhotoService.cs
@@ -79,4 +79,10 @@ public class PhotoService : IPhotoService
             return ApiResult<PhotoDto>.Failure($"Failed to load photo: {ex.Message}");
         }
     }
+
+    public async Task<ApiResult<object>> DeletePhotoAsync(Guid photoId)
+    {
+        var url = $"{_url}/{photoId}";
+        return await _httpService.DeleteAsync<object>(url);
+    }
 }

--- a/Lumix.Blazor/Services/UserService.cs
+++ b/Lumix.Blazor/Services/UserService.cs
@@ -37,5 +37,25 @@ namespace Lumix.Blazor.Services
                 return ApiResult<UserProfileDto>.Failure(ex.Message);
             }
         }
+
+        public async Task<ApiResult<Guid>> GetMeAsync()
+        {
+            try
+            {
+                _logger.LogInformation("Getting current user");
+                var response = await _httpService.GetAsync<Guid>($"{_url}/me");
+                if (response.IsSuccess && response.Value != null)
+                {
+                    _logger.LogInformation("Current user retrieved");
+                    return ApiResult<Guid>.Success(response.Value);
+                }
+                return ApiResult<Guid>.Failure(response.ErrorMessage ?? "Unknown API error");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to get current user");
+                return ApiResult<Guid>.Failure(ex.Message);
+            }
+        }
+        }
     }
-}


### PR DESCRIPTION
## Enable photo deletion by owner in photo details dialog
Adds support for users to delete their own photos from the photo details dialog. Includes a delete button with confirmation, visible only to the photo's author. Updates the UI to remove deleted photos from the profile view. Extends `IPhotoService` and `HttpService` to support photo deletion, and adds `GetMeAsync` to `IUserService` for current user identification. Minor UI improvements included.