### PR TITLE
Comment deletion and refactored user Id retrieving

### DIFF
--- a/Lumix.Blazor/Components/Photo/PhotoDetailsDialog.razor
+++ b/Lumix.Blazor/Components/Photo/PhotoDetailsDialog.razor
@@ -25,7 +25,7 @@
                 </MudItem>
 
                 <MudItem xs="12" md="5" Class="d-flex flex-column">
-                    <PhotoDialogComments Photo="Photo" CurrentUser="CurrentUser" CurrentUserId="CurrentUserId" OnAddComment="HandleCommentAdded" />
+                    <PhotoDialogComments Photo="Photo" CurrentUser="CurrentUser" OnAddComment="HandleCommentAdded" />
                 </MudItem>
             </MudGrid>
         }

--- a/Lumix.Blazor/Components/Photo/PhotoDetailsDialog.razor.cs
+++ b/Lumix.Blazor/Components/Photo/PhotoDetailsDialog.razor.cs
@@ -12,7 +12,6 @@ namespace Lumix.Blazor.Components.Photo
         [CascadingParameter] MudDialogInstance MudDialog { get; set; }
         [Parameter] public Guid PhotoId { get; set; }
         [Parameter] public UserProfileDto CurrentUser { get; set; }
-        [Parameter] public Guid CurrentUserId { get; set; }
         [Inject] public IPhotoService PhotoService { get; set; } = default!;
         [Inject] public ICommentService CommentService { get; set; } = default!;
         [Inject] public ISnackbar Snackbar { get; set; } = default!;

--- a/Lumix.Blazor/Components/Photo/PhotoDialogComments.razor
+++ b/Lumix.Blazor/Components/Photo/PhotoDialogComments.razor
@@ -122,11 +122,29 @@
                                             </MudButton>
                                         </MudStack>
 
-                                        <MudText Typo="Typo.caption"
-                                                 Color="Color.Default"
-                                                 Class="comment-time">
-                                            @GetRelativeTime(comment.CreatedAt)
-                                        </MudText>
+                                        <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center" Justify="Justify.FlexEnd">
+                                            <MudText Typo="Typo.caption"
+                                                     Color="Color.Default"
+                                                     Class="comment-time">
+                                                @GetRelativeTime(comment.CreatedAt)
+                                            </MudText>
+                                            @if (CanDeleteComment(comment))
+                                            {
+                                                <MudMenu AnchorOrigin="Origin.TopRight" TransformOrigin="Origin.TopRight" Dense="true">
+                                                    <ActivatorContent>
+                                                        <MudIconButton Icon="@Icons.Material.Filled.MoreVert" Size="Size.Small" />
+                                                    </ActivatorContent>
+
+                                                    <ChildContent>
+                                                        <MudMenuItem OnClick="@(() => ConfirmDeleteComment(comment.Id))">
+                                                            <MudIcon Icon="@Icons.Material.Filled.Delete" Class="me-2" />
+                                                            Видалити коментар
+                                                        </MudMenuItem>
+                                                    </ChildContent>
+                                                </MudMenu>
+                                            }
+                                        </MudStack>
+
                                     </MudStack>
 
                                     <MudText Typo="Typo.body2" Class="mt-1 ml-8">
@@ -158,11 +176,29 @@
                                                         </MudText>
                                                     </MudStack>
 
-                                                    <MudText Typo="Typo.caption"
-                                                             Color="Color.Default"
-                                                             Class="comment-time">
-                                                        @GetRelativeTime(reply.CreatedAt)
-                                                    </MudText>
+                                                    <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center" Justify="Justify.FlexEnd">
+                                                        <MudText Typo="Typo.caption"
+                                                                 Color="Color.Default"
+                                                                 Class="comment-time">
+                                                            @GetRelativeTime(reply.CreatedAt)
+                                                        </MudText>
+                                                    
+                                                        @if (CanDeleteComment(reply))
+                                                        {
+                                                            <MudMenu AnchorOrigin="Origin.TopRight" TransformOrigin="Origin.TopRight" Dense="true">
+                                                                <ActivatorContent>
+                                                                    <MudIconButton Icon="@Icons.Material.Filled.MoreVert" Size="Size.Small" />
+                                                                </ActivatorContent>
+
+                                                                <ChildContent>
+                                                                    <MudMenuItem OnClick="@(() => ConfirmDeleteComment(reply.Id))">
+                                                                        <MudIcon Icon="@Icons.Material.Filled.Delete" Class="me-2" />
+                                                                        Видалити коментар
+                                                                    </MudMenuItem>
+                                                                </ChildContent>
+                                                            </MudMenu>
+                                                        }
+                                                    </MudStack>
                                                 </MudStack>
 
                                                 <MudText Typo="Typo.body2" Class="mt-1 ml-8">

--- a/Lumix.Blazor/Components/Photo/PhotoDialogComments.razor.cs
+++ b/Lumix.Blazor/Components/Photo/PhotoDialogComments.razor.cs
@@ -1,34 +1,42 @@
-﻿using System.Runtime.InteropServices;
-using Lumix.Blazor.Data.Comment;
+﻿using Lumix.Blazor.Data.Comment;
 using Lumix.Blazor.Data.Photo;
 using Lumix.Blazor.Data.User;
+using Lumix.Blazor.Extensions;
 using Lumix.Blazor.Services.IServices;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Authorization;
 using MudBlazor;
 
 namespace Lumix.Blazor.Components.Photo
 {
     public partial class PhotoDialogComments
     {
-        [CascadingParameter]
-        private MudDialogInstance MudDialog { get; set; } = default!;
+        [CascadingParameter] private MudDialogInstance MudDialog { get; set; } = null!;
         [Parameter] public PhotoDto Photo { get; set; }
         [Parameter] public UserProfileDto CurrentUser { get; set; }
-        [Parameter] public Guid CurrentUserId { get; set; }
         [Parameter] public EventCallback<CommentRequest> OnAddComment { get; set; }
         [Inject] public IDialogService DialogService { get; set; }
         [Inject] public IPhotoService PhotoService { get; set; }
+        [Inject] public ICommentService CommentService { get; set; }
         [Inject] public ISnackbar Snackbar { get; set; }
+        [Inject] public AuthenticationStateProvider AuthStateProvider { get; set; } = null!;
 
         public string NewComment { get; set; } = string.Empty;
         public Guid? ReplyParentId { get; set; } = null;
         public string? ReplyToUsername { get; set; } = null;
+        private Guid? _currentUserId;
         public bool CanDeletePhoto { get; set; }
 
-        protected override Task OnInitializedAsync()
+        protected override async Task OnInitializedAsync()
         {
-            CanDeletePhoto = CurrentUserId == Photo.Author.Id;
-            return base.OnInitializedAsync();
+            var authState = await AuthStateProvider.GetAuthenticationStateAsync();
+            _currentUserId = authState.User.GetUserId();
+        }
+
+        protected override void OnParametersSet()
+        {
+            CanDeletePhoto = _currentUserId.HasValue
+                             && _currentUserId.Value == Photo.Author.Id;
         }
 
         private async Task SubmitComment()
@@ -79,13 +87,59 @@ namespace Lumix.Blazor.Components.Photo
                 yesText: "Видалити",
                 cancelText: "Скасувати"
             );
-            if (confirmed != true)
+            if (!confirmed!.Value)
                 return;
             await PhotoService.DeletePhotoAsync(photoId);
 
             Snackbar.Add("Фото видалено", Severity.Success);
 
             MudDialog.Close(DialogResult.Ok(photoId));
+        }
+
+        private async Task ConfirmDeleteComment(Guid commentId)
+        {
+            var confirmed = await DialogService.ShowMessageBox(
+                title: "Видалити коментар?",
+                message: "Коментар буде видалено назавжди.",
+                yesText: "Видалити",
+                cancelText: "Скасувати"
+            );
+            if (!confirmed!.Value)
+                return;
+            await CommentService.DeleteCommentAsync(commentId, Photo.Id);
+            DeleteCommentFromDto(commentId);
+
+            Snackbar.Add("Коментар видалено", Severity.Success);
+            StateHasChanged();
+        }
+
+        private bool CanDeleteComment(CommentDto comment)
+        {
+            return _currentUserId.HasValue
+                   && (
+                       comment.Author.Id == _currentUserId.Value
+                       || Photo.Author.Id == _currentUserId.Value
+                   );
+        }
+
+        private void DeleteCommentFromDto(Guid commentId)
+        {
+            var root = Photo.Comments.FirstOrDefault(c => c.Id == commentId);
+            if (root != null)
+            {
+                Photo.Comments.Remove(root);
+                return;
+            }
+
+            foreach (var comment in Photo.Comments)
+            {
+                var reply = comment.Children.FirstOrDefault(c => c.Id == commentId);
+                if (reply != null)
+                {
+                    comment.Children.Remove(reply);
+                    return;
+                }
+            }
         }
     }
 }

--- a/Lumix.Blazor/Data/Photo/PhotoDto.cs
+++ b/Lumix.Blazor/Data/Photo/PhotoDto.cs
@@ -15,7 +15,7 @@ namespace Lumix.Blazor.Data.Photo
         public int LikeCount { get; set; }
         public bool IsAvatar { get; set; }
 
-        public UserPreviewDto Author { get; set; } = default!;
+        public UserPreviewDto Author { get; set; } = null!;
         public List<LikeDto> Likes { get; set; } = new();
         public List<CommentDto> Comments { get; set; } = new();
         public List<PhotoTagDto> PhotoTags { get; set; } = new();

--- a/Lumix.Blazor/Extensions/ClaimExtensions.cs
+++ b/Lumix.Blazor/Extensions/ClaimExtensions.cs
@@ -1,0 +1,15 @@
+﻿using System.Security.Claims;
+
+namespace Lumix.Blazor.Extensions
+{
+    public static class ClaimExtensions
+    {
+        public static Guid? GetUserId(this ClaimsPrincipal user)
+        {
+            var userIdClaim = user.FindFirstValue("userId");
+            return Guid.TryParse(userIdClaim, out var id)
+                ? id
+                : null;
+        }
+    }
+}

--- a/Lumix.Blazor/Pages/Profile.razor
+++ b/Lumix.Blazor/Pages/Profile.razor
@@ -1,49 +1,6 @@
 @page "/profile"
-@using Lumix.Blazor.Components.Photo
-@using Lumix.Blazor.Data.User
-@using Lumix.Blazor.Services.IServices
-@inject IUserService UserService
-@inject IDialogService DialogService
-@inject AuthenticationStateProvider AuthStateProvider
 
 @using Lumix.Blazor.Components.Profile;
 
 
 <ProfileCard Profile="@ProfileDto" OnOpenPhoto="@OpenPhotoDialog"/>
-
-
-@code {
-    public UserProfileDto ProfileDto { get; set; } = new();
-    private bool _isInitialized = false;
-    public Guid CurrentUserId { get; set; }
-
-    protected override async Task OnInitializedAsync()
-    {
-        var result = await UserService.GetProfileAsync();
-        ProfileDto = result.Value;
-        _isInitialized = true;
-        CurrentUserId = (await UserService.GetMeAsync()).Value;
-    }
-
-    private async Task OpenPhotoDialog(Guid photoId)
-    {
-        var options = new DialogOptions
-        {
-            MaxWidth = MaxWidth.ExtraLarge,
-            FullWidth = true,
-            CloseOnEscapeKey = true,
-            CloseButton = true
-        };
-
-        var parameters = new DialogParameters { { "PhotoId", photoId }, {"CurrentUser", ProfileDto }, { "CurrentUserId", CurrentUserId } };
-
-        var dialog = await DialogService.ShowAsync<PhotoDetailsDialog>("", parameters, options);
-        var result = await dialog.Result;
-
-        if (!result.Cancelled && result.Data is Guid deletedPhotoId)
-        {
-            ProfileDto.Photos.RemoveAll(p => p.Id == deletedPhotoId);
-        }
-
-    }
-}

--- a/Lumix.Blazor/Pages/Profile.razor.cs
+++ b/Lumix.Blazor/Pages/Profile.razor.cs
@@ -1,0 +1,43 @@
+﻿using Lumix.Blazor.Components.Photo;
+using Lumix.Blazor.Data.User;
+using Lumix.Blazor.Services.IServices;
+using Microsoft.AspNetCore.Components;
+using MudBlazor;
+
+namespace Lumix.Blazor.Pages
+{
+    public partial class Profile
+    {
+        public UserProfileDto? ProfileDto { get; set; } = new();
+        [Inject] private IUserService UserService { get; set; } = null!;
+        [Inject] private IDialogService DialogService { get; set; } = null!;
+
+        protected override async Task OnInitializedAsync()
+        {
+            var result = await UserService.GetProfileAsync();
+            ProfileDto = result.Value;
+        }
+
+        private async Task OpenPhotoDialog(Guid photoId)
+        {
+            var options = new DialogOptions
+            {
+                MaxWidth = MaxWidth.ExtraLarge,
+                FullWidth = true,
+                CloseOnEscapeKey = true,
+                CloseButton = true
+            };
+
+            var parameters = new DialogParameters { { "PhotoId", photoId }, { "CurrentUser", ProfileDto } };
+
+            var dialog = await DialogService.ShowAsync<PhotoDetailsDialog>("", parameters, options);
+            var result = await dialog.Result;
+
+            if (!result.Cancelled && result.Data is Guid deletedPhotoId)
+            {
+                ProfileDto?.Photos.RemoveAll(p => p.Id == deletedPhotoId);
+            }
+
+        }
+    }
+}

--- a/Lumix.Blazor/Services/CommentService.cs
+++ b/Lumix.Blazor/Services/CommentService.cs
@@ -56,5 +56,11 @@ namespace Lumix.Blazor.Services
                 return ApiResult<CommentDto>.Failure($"Помилка при відправці коментаря: {ex.Message}");
             }
         }
+
+        public async Task<ApiResult<object>> DeleteCommentAsync(Guid commentId, Guid photoId)
+        {
+            var url = $"{_url}/{commentId}/{photoId}";
+            return await _httpService.DeleteAsync<object>(url);
+        }
     }
 }

--- a/Lumix.Blazor/Services/IServices/ICommentService.cs
+++ b/Lumix.Blazor/Services/IServices/ICommentService.cs
@@ -7,5 +7,6 @@ namespace Lumix.Blazor.Services.IServices
     {
         Task<ApiResult<CommentDto>> PostCommentAsync(Guid photoId, CommentRequest comment);
         Task<ApiResult<IEnumerable<CommentDto>>> GetCommentByIdAsync(Guid photoId);
+        Task<ApiResult<object>> DeleteCommentAsync(Guid commentId, Guid photoId);
     }
 }

--- a/Lumix.Blazor/Services/IServices/IUserService.cs
+++ b/Lumix.Blazor/Services/IServices/IUserService.cs
@@ -6,6 +6,6 @@ namespace Lumix.Blazor.Services.IServices
     public interface IUserService
     {
         Task<ApiResult<UserProfileDto>> GetProfileAsync();
-        public Task<ApiResult<Guid>> GetMeAsync();
+        Task<ApiResult<Guid>> GetMeAsync();
     }
 }


### PR DESCRIPTION
#### PR Classification
New feature and code refactor to support comment deletion and improve user identification in the photo dialog.

#### PR Summary
This PR adds the ability for users to delete their own comments or comments on their photos, and refactors user identification logic in the photo dialog components.
- PhotoDialogComments.razor and .cs: Implements comment deletion UI and logic, including permission checks and backend integration.
- ClaimExtensions.cs: Adds an extension method to extract the user ID from authentication claims.
- ICommentService.cs and CommentService.cs: Adds DeleteCommentAsync method for comment deletion via API.
- Profile.razor and Profile.razor.cs: Refactors code-behind logic and removes unnecessary CurrentUserId parameter.
- PhotoDetailsDialog.razor and .cs: Updates to use new user identification approach and removes CurrentUserId parameter.
